### PR TITLE
Extend the simulation and example steps.

### DIFF
--- a/osb-service/src/main/java/de/evoila/cf/broker/service/custom/ExampleBackendRawService.java
+++ b/osb-service/src/main/java/de/evoila/cf/broker/service/custom/ExampleBackendRawService.java
@@ -3,6 +3,9 @@
  */
 package de.evoila.cf.broker.service.custom;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * @author Johannes Hiemer
  * This class contains a specific implementation for the access to the 
@@ -14,7 +17,9 @@ package de.evoila.cf.broker.service.custom;
  * API.
  */
 public class ExampleBackendRawService {
-	
+
+	protected Logger log = LoggerFactory.getLogger(getClass());
+
 	private boolean initialized;
 	
 	public void createConnection() {
@@ -25,8 +30,20 @@ public class ExampleBackendRawService {
 		return this.initialized;
 	}
 
-	public void bind() {
-		// We bind 
+	public void createDatabase(String databaseName) {
+		log.info("Created an example service \""+databaseName+"\".");
+	}
+
+	public void deleteDatabase(String databaseName) {
+		log.info("Deleted an example service \""+databaseName+"\".");
+	}
+
+	public void bind(String databaseName, String username) {
+		log.info("Bound \""+username+"\" to example service \""+databaseName+"\".");
+	}
+
+	public void unbind(String databaseName, String username) {
+		log.info("Unbound \""+username+"\" from example service \""+databaseName+"\".");
 	}
 
 }

--- a/osb-service/src/main/java/de/evoila/cf/cpi/existing/ExampleExistingServiceFactory.java
+++ b/osb-service/src/main/java/de/evoila/cf/cpi/existing/ExampleExistingServiceFactory.java
@@ -7,14 +7,17 @@ import de.evoila.cf.broker.bean.ExistingEndpointBean;
 import de.evoila.cf.broker.model.Platform;
 import de.evoila.cf.broker.model.ServiceInstance;
 import de.evoila.cf.broker.model.catalog.plan.Plan;
+import de.evoila.cf.broker.model.credential.UsernamePasswordCredential;
 import de.evoila.cf.broker.repository.PlatformRepository;
 import de.evoila.cf.broker.service.availability.ServicePortAvailabilityVerifier;
+import de.evoila.cf.broker.service.custom.ExampleBackendRawService;
 import de.evoila.cf.broker.service.custom.ExampleBackendService;
 import de.evoila.cf.security.credentials.CredentialStore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 
+import java.util.LinkedList;
 import java.util.Map;
 
 /**
@@ -49,34 +52,41 @@ public class ExampleExistingServiceFactory extends ExistingServiceFactory {
 
     @Override
     public ServiceInstance createInstance(ServiceInstance serviceInstance, Plan plan, Map<String, Object> customParameters) {
-        credentialStore.createUser(serviceInstance, ROOT_USER);
-
+        UsernamePasswordCredential credentials = credentialStore.createUser(serviceInstance, ROOT_USER);
         createDatabase(serviceInstance, plan);
-
         return serviceInstance;
     }
 
     @Override
     public void deleteInstance(ServiceInstance serviceInstance, Plan plan) {
-        credentialStore.deleteCredentials(serviceInstance, ROOT_USER);
+        UsernamePasswordCredential credential = credentialStore.getUser(serviceInstance, ROOT_USER);
         deleteDatabase(serviceInstance, plan);
+        credentialStore.deleteCredentials(serviceInstance, ROOT_USER);
     }
 
     private void deleteDatabase(ServiceInstance serviceInstance, Plan plan) {
         log.info("Deleting the Example Service...");
+        ExampleBackendRawService backendRawService = getConnection(plan);
+        if (backendRawService != null) {
+            log.info("Example Service connection status: "+ (backendRawService.isConnected() ? "" : "not ") + "connected");
+            backendRawService.deleteDatabase(serviceInstance.getId());
+        }
     }
 
     private void createDatabase(ServiceInstance serviceInstance, Plan plan) {
         log.info("Creating the Example Service...");
+        ExampleBackendRawService backendRawService = getConnection(plan);
+        if (backendRawService != null) {
+            log.info("Example Service connection status: "+ (backendRawService.isConnected() ? "" : "not ") + "connected");
+            backendRawService.createDatabase(serviceInstance.getId());
+        }
     }
 
-    private ExampleBackendService connection(ServiceInstance serviceInstance, Plan plan) {
-        ExampleBackendService jdbcService = new ExampleBackendService();
-
+    public ExampleBackendRawService getConnection(Plan plan) {
+        ExampleBackendRawService backendRawService = null;
         if (plan.getPlatform() == Platform.EXISTING_SERVICE)
-            jdbcService.createConnection(existingEndpointBean.getUsername(), existingEndpointBean.getPassword(),
-                    existingEndpointBean.getDatabase(), existingEndpointBean.getHosts());
-
-        return jdbcService;
+            backendRawService = exampleBackendService.createConnection(existingEndpointBean.getUsername(),
+                    existingEndpointBean.getPassword(),null, existingEndpointBean.getHosts());
+        return backendRawService;
     }
 }


### PR DESCRIPTION
This PR adds usage of the ExampleBackendService and ExampleBackendRawService to give an example on how to use these in our service brokers. Therefore a creation and deletion of a simulated database is added, as well as an "implementation" of bind and unbind. Furthermore is the binding process tweaked to get closer to our implementations in other brokers.

The goal is to get the osb-example from an empty blueprint to a shallow but working service broker, that gives a kickstart, when developing a new service broker.